### PR TITLE
Create bash_profile

### DIFF
--- a/helpers/bash_profile
+++ b/helpers/bash_profile
@@ -1,0 +1,1 @@
+[[ -s ~/.bashrc ]] && source ~/.bashrc


### PR DESCRIPTION
In mac terminal, bashrc does not work until you add this line to your bash_profile